### PR TITLE
Automatically remove current dial code from input if inputted

### DIFF
--- a/lib/src/utils/formatter/as_you_type_formatter.dart
+++ b/lib/src/utils/formatter/as_you_type_formatter.dart
@@ -32,6 +32,15 @@ class AsYouTypeFormatter extends TextInputFormatter {
   @override
   TextEditingValue formatEditUpdate(
       TextEditingValue oldValue, TextEditingValue newValue) {
+    // Fixes autofill and manually typing the dial code in the input
+    if (newValue.text.startsWith(dialCode)) {
+      final newValueText = newValue.text.replaceFirst(dialCode, '');
+      newValue = newValue.copyWith(
+        text: newValueText,
+        selection: TextSelection.collapsed(offset: newValueText.length),
+      );
+    }
+
     int oldValueLength = oldValue.text.length;
     int newValueLength = newValue.text.length;
 


### PR DESCRIPTION
This fixes cases where autofill would input a phone number with the dial code by removing it.
Current limitation: It does not automatically update the current dial code if another dial code gets inputted. It only works on the currently selected dial code.
You can also input the phone number with your dial code manually and it will be removed.