### PR TITLE
fix: Adjusting valueInInputIndex validation

### DIFF
--- a/lib/src/utils/formatter/as_you_type_formatter.dart
+++ b/lib/src/utils/formatter/as_you_type_formatter.dart
@@ -54,9 +54,9 @@ class AsYouTypeFormatter extends TextInputFormatter {
               newValue.selection.end == -1 ? 0 : newValue.selection.end;
 
           if (separatorChars.hasMatch(parsedText)) {
-            String valueInInputIndex = parsedText[offset - 1];
-
             if (offset < parsedText.length) {
+              String valueInInputIndex = parsedText[offset - 1];
+
               int offsetDifference = parsedText.length - offset;
 
               if (offsetDifference < 2) {


### PR DESCRIPTION
Describe the bug
I just have a report from Sentry, no information about how to reproduce.

Package version
0.7.14

Flutter version
3.19.5

To Reproduce
Unknown, I just have the crash report from Crashlytics without anything else.

Expected behavior
Not to bug.

Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: RangeError (index): Invalid value: Not in inclusive range 0..3: 7
#00 pc 0x8657e0 com.myapp.app (_StringBase.[] [string_patch.dart:273]) (BuildId: ec846970599136b05ad68741d8ce9fc5)
#01 pc 0x8ece37 com.myapp.app (AsYouTypeFormatter.formatEditUpdate.<anonymous closure> [as_you_type_formatter.dart:57]) (BuildId: ec846970599136b05ad68741d8ce9fc5)
#02 pc 0x867de8 com.myapp.app (Future._propagateToListeners.handleValueCallback [future_impl.dart:838]) (BuildId: ec846970599136b05ad68741d8ce9fc5)
#03 pc 0x25bc95 com.myapp.app (Future._propagateToListeners [future_impl.dart:867]) (BuildId: ec846970599136b05ad68741d8ce9fc5)
#04 pc 0x25ce67 com.myapp.app (Future._completeWithValue [future_impl.dart:643]) (BuildId: ec846970599136b05ad68741d8ce9fc5)
#05 pc 0x857033 com.myapp.app (_SuspendState._returnAsync [async_patch.dart:352]) (BuildId: ec846970599136b05ad68741d8ce9fc5)