### PR TITLE
Conversion of Turkey to Türkiye

### DIFF
--- a/lib/src/models/country_list.dart
+++ b/lib/src/models/country_list.dart
@@ -7242,7 +7242,7 @@ class Countries {
       "num_code": "792",
       "alpha_2_code": "TR",
       "alpha_3_code": "TUR",
-      "en_short_name": "Turkey",
+      "en_short_name": "Türkiye",
       "nationality": "Turkish",
       "dial_code": "+90",
       "nameTranslations": {
@@ -7257,7 +7257,7 @@ class Countries {
         "de": "Türkei",
         "fr": "Turquie",
         "es": "Turquía",
-        "en": "Turkey",
+        "en": "Türkiye",
         "pt_BR": "Peru",
         "sr-Cyrl": "Турска",
         "sr-Latn": "Turska",


### PR DESCRIPTION
Ref:

- https://www.theguardian.com/us-news/2023/jan/05/us-turkey-spelling-turkiye-country

- https://www.euronews.com/my-europe/2022/06/28/turkey-is-now-turkiye-what-other-countries-have-changed-their-name