### PR TITLE
Fix ListTile FlutterError in Flutter 3.44.4

### DIFF
--- a/lib/src/widgets/countries_search_list_widget.dart
+++ b/lib/src/widgets/countries_search_list_widget.dart
@@ -147,26 +147,29 @@ class DirectionalCountryListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      key: Key(TestHelper.countryItemKeyValue(country.alpha2Code)),
-      leading: (showFlags ? _Flag(country: country, useEmoji: useEmoji) : null),
-      title: Align(
-        alignment: AlignmentDirectional.centerStart,
-        child: Text(
-          '${Utils.getCountryName(country, locale)}',
-          textDirection: Directionality.of(context),
-          textAlign: TextAlign.start,
+    return Material(
+      color: Colors.transparent,
+      child: ListTile(
+        key: Key(TestHelper.countryItemKeyValue(country.alpha2Code)),
+        leading: (showFlags ? _Flag(country: country, useEmoji: useEmoji) : null),
+        title: Align(
+          alignment: AlignmentDirectional.centerStart,
+          child: Text(
+            '${Utils.getCountryName(country, locale)}',
+            textDirection: Directionality.of(context),
+            textAlign: TextAlign.start,
+          ),
         ),
-      ),
-      subtitle: Align(
-        alignment: AlignmentDirectional.centerStart,
-        child: Text(
-          '${country.dialCode ?? ''}',
-          textDirection: TextDirection.ltr,
-          textAlign: TextAlign.start,
+        subtitle: Align(
+          alignment: AlignmentDirectional.centerStart,
+          child: Text(
+            '${country.dialCode ?? ''}',
+            textDirection: TextDirection.ltr,
+            textAlign: TextAlign.start,
+          ),
         ),
+        onTap: () => Navigator.of(context).pop(country),
       ),
-      onTap: () => Navigator.of(context).pop(country),
     );
   }
 }


### PR DESCRIPTION
Problem:
see also breaking change https://docs.flutter.dev/release/breaking-changes/list-tile-color-warning

When upgrading from Flutter 3.41.4 to 3.44.4 I got the following runtime error:

```
════════ Exception caught by Flutter framework ═════════════════════════════════
The following assertion was thrown:
ListTile background color or ink splashes may be invisible.
The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.

ListTile: ListTile-[<'intl_country_AF_key'>]
    onTap: Closure: () => void
DecoratedBox: DecoratedBox
    bg: ShapeDecoration(color: Color(alpha: 1.0000, red: 0.6784, green: 0.7804, blue: 0.8627, colorSpace: ColorSpace.sRGB), shape: RoundedRectangleBorder(BorderSide(width: 0.0, style: none), BorderRadius.only(topLeft: Radius.circular(12.0), topRight: Radius.circular(12.0))))
        color: Color(alpha: 1.0000, red: 0.6784, green: 0.7804, blue: 0.8627, colorSpace: ColorSpace.sRGB)
        shape: RoundedRectangleBorder(BorderSide(width: 0.0, style: none), BorderRadius.only(topLeft: Radius.circular(12.0), topRight: Radius.circular(12.0)))
════════════════════════════════════════════════════════════════════════════════
[sentry.flutterError] [error] Exception caught by Flutter framework
[sentry.flutterError] FlutterError (ListTile background color or ink splashes may be invisible.
                      The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
                      To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.)

════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════
[sentry.flutterError] [error] Exception caught by Flutter framework
[sentry.flutterError] FlutterError (ListTile background color or ink splashes may be invisible.
                      The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
                      To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.)

════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════
[sentry.flutterError] [error] Exception caught by Flutter framework
[sentry.flutterError] FlutterError (ListTile background color or ink splashes may be invisible.
                      The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
                      To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.)
[sentry.flutterError] [error] Exception caught by Flutter framework
[sentry.flutterError] FlutterError (ListTile background color or ink splashes may be invisible.
                      The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
                      To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.)

════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════
[sentry.flutterError] [error] Exception caught by Flutter framework
[sentry.flutterError] FlutterError (ListTile background color or ink splashes may be invisible.
                      The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
                      To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.)

════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════
[sentry.flutterError] [error] Exception caught by Flutter framework
[sentry.flutterError] FlutterError (ListTile background color or ink splashes may be invisible.
                      The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
                      To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.)
[sentry.flutterError] [error] Exception caught by Flutter framework
[sentry.flutterError] FlutterError (ListTile background color or ink splashes may be invisible.
                      The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
                      To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.)
[sentry.flutterError] [error] Exception caught by Flutter framework
[sentry.flutterError] FlutterError (ListTile background color or ink splashes may be invisible.
                      The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
                      To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.)
[sentry.flutterError] [error] Exception caught by Flutter framework
[sentry.flutterError] FlutterError (ListTile background color or ink splashes may be invisible.
                      The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
                      To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.)
```
The suggested fix in the error message is "To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox."

As a solution I chose wrapping the ListTile in a Material widget because I don't know it better :). 

